### PR TITLE
Made the SelectableOpMode use the dpad (one handed)

### DIFF
--- a/Sixteen750/src/main/java/org/firstinspires/ftc/sixteen750/opmodes/Tuning.java
+++ b/Sixteen750/src/main/java/org/firstinspires/ftc/sixteen750/opmodes/Tuning.java
@@ -15,15 +15,13 @@ import com.pedropathing.math.Vector;
 import com.pedropathing.paths.HeadingInterpolator;
 import com.pedropathing.paths.Path;
 import com.pedropathing.paths.PathChain;
-import com.pedropathing.telemetry.SelectableOpMode;
 import com.pedropathing.util.PoseHistory;
 import com.qualcomm.robotcore.eventloop.opmode.OpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
-
-import org.firstinspires.ftc.sixteen750.AutoConstants;
-
+import com.technototes.library.structure.BetterSelectableOpMode;
 import java.util.ArrayList;
 import java.util.List;
+import org.firstinspires.ftc.sixteen750.AutoConstants;
 
 /**
  * This is the Tuning class. It contains a selection menu for various tuning OpModes.
@@ -33,7 +31,7 @@ import java.util.List;
  */
 
 @TeleOp(name = "Tuning", group = "Pedro Pathing")
-public class Tuning extends SelectableOpMode {
+public class Tuning extends BetterSelectableOpMode {
 
     public static Follower follower;
 
@@ -341,10 +339,10 @@ class TurnTuner extends OpMode {
     @Override
     public void loop() {
         Tuning.follower.setTeleOpDrive(
-                -gamepad1.left_stick_y,
-                -gamepad1.left_stick_x,
-                -gamepad1.right_stick_x,
-                true
+            -gamepad1.left_stick_y,
+            -gamepad1.left_stick_x,
+            -gamepad1.right_stick_x,
+            true
         );
         Tuning.follower.update();
 
@@ -364,6 +362,7 @@ class TurnTuner extends OpMode {
 
         Tuning.drawCurrentAndHistory();
     }
+
     @Override
     public void start() {
         Tuning.follower.startTeleopDrive(true);
@@ -450,7 +449,7 @@ class ForwardVelocityTuner extends OpMode {
             telemetry.addData("PoseY", p.getY());
             telemetry.addData("PoseHeading", p.getHeading());
             telemetry.update();
-            if (Math.abs(Tuning.follower.getPose().getY()) > DISTANCE)  {
+            if (Math.abs(Tuning.follower.getPose().getY()) > DISTANCE) {
                 end = true;
                 Tuning.stopRobot();
             } else {
@@ -572,7 +571,9 @@ class LateralVelocityTuner extends OpMode {
                 Tuning.stopRobot();
             } else {
                 Tuning.follower.setTeleOpDrive(0, 1, 0, true);
-                double currentVelocity = Math.abs(Tuning.follower.poseTracker.getLocalizer().getVelocity().getX());
+                double currentVelocity = Math.abs(
+                    Tuning.follower.poseTracker.getLocalizer().getVelocity().getX()
+                );
                 velocities.add(currentVelocity);
                 velocities.remove(0);
             }
@@ -924,7 +925,9 @@ class HeadingTuner extends OpMode {
         Tuning.telemetryM.debug(
             "The robot will try to stay at a constant heading while you try to turn it."
         );
-        Tuning.telemetryM.debug("You can adjust the PIDF values to tune the robot's heading PIDF(s).");
+        Tuning.telemetryM.debug(
+            "You can adjust the PIDF values to tune the robot's heading PIDF(s)."
+        );
         Tuning.telemetryM.update(telemetry);
         Tuning.follower.update();
         Tuning.drawCurrent();
@@ -994,7 +997,9 @@ class DriveTuner extends OpMode {
         Tuning.telemetryM.debug(
             "This will run the robot in a straight line going " + DISTANCE + "inches forward."
         );
-        Tuning.telemetryM.debug("The robot will go forward and backward continuously along the path.");
+        Tuning.telemetryM.debug(
+            "The robot will go forward and backward continuously along the path."
+        );
         Tuning.telemetryM.debug("Make sure you have enough room.");
         Tuning.telemetryM.update(telemetry);
         Tuning.follower.update();
@@ -1075,7 +1080,9 @@ class Line extends OpMode {
         Tuning.telemetryM.debug(
             "The robot will go forward and backward continuously along the path while correcting."
         );
-        Tuning.telemetryM.debug("You can adjust the PIDF values to tune the robot's drive PIDF(s).");
+        Tuning.telemetryM.debug(
+            "You can adjust the PIDF values to tune the robot's drive PIDF(s)."
+        );
         Tuning.telemetryM.update(telemetry);
         Tuning.follower.update();
         Tuning.drawCurrent();

--- a/TechnoLib/RobotLibrary/src/main/java/com/technototes/library/structure/BetterSelectableOpMode.java
+++ b/TechnoLib/RobotLibrary/src/main/java/com/technototes/library/structure/BetterSelectableOpMode.java
@@ -1,0 +1,88 @@
+package com.technototes.library.structure;
+
+import com.pedropathing.telemetry.SelectScope;
+import com.pedropathing.telemetry.Selector;
+import com.qualcomm.robotcore.eventloop.opmode.OpMode;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+public abstract class BetterSelectableOpMode extends OpMode {
+
+    private final Selector<Supplier<OpMode>> selector;
+    private OpMode selectedOpMode;
+    private static final String[] MESSAGE = {
+        "Use the d-pad to move the cursor.",
+        "Press right bumper or dpad right to select.",
+        "Press left bumper to dpad left go back.",
+    };
+
+    public BetterSelectableOpMode(String name, Consumer<SelectScope<Supplier<OpMode>>> opModes) {
+        selector = Selector.create(name, opModes, MESSAGE);
+        selector.onSelect(opModeSupplier -> {
+            onSelect();
+            selectedOpMode = opModeSupplier.get();
+            selectedOpMode.gamepad1 = gamepad1;
+            selectedOpMode.gamepad2 = gamepad2;
+            selectedOpMode.telemetry = telemetry;
+            selectedOpMode.hardwareMap = hardwareMap;
+            selectedOpMode.init();
+        });
+    }
+
+    protected void onSelect() {}
+
+    protected void onLog(List<String> line) {}
+
+    @Override
+    public final void init() {}
+
+    @Override
+    public final void init_loop() {
+        if (selectedOpMode == null) {
+            if (gamepad1.dpadUpWasPressed() || gamepad2.dpadUpWasPressed()) {
+                selector.decrementSelected();
+            } else if (gamepad1.dpadDownWasPressed() || gamepad2.dpadDownWasPressed()) {
+                selector.incrementSelected();
+            } else if (
+                gamepad1.rightBumperWasPressed() ||
+                gamepad2.rightBumperWasPressed() ||
+                gamepad1.dpadRightWasPressed() ||
+                gamepad2.dpadRightWasPressed()
+            ) {
+                selector.select();
+            } else if (
+                gamepad1.leftBumperWasPressed() ||
+                gamepad2.leftBumperWasPressed() ||
+                gamepad1.dpadLeftWasPressed() ||
+                gamepad2.dpadLeftWasPressed()
+            ) {
+                selector.goBack();
+            }
+
+            List<String> lines = selector.getLines();
+            for (String line : lines) {
+                telemetry.addLine(line);
+            }
+            onLog(lines);
+        } else {
+            selectedOpMode.init_loop();
+        }
+    }
+
+    @Override
+    public final void start() {
+        if (selectedOpMode == null) throw new RuntimeException("No OpMode selected!");
+        selectedOpMode.start();
+    }
+
+    @Override
+    public final void loop() {
+        selectedOpMode.loop();
+    }
+
+    @Override
+    public final void stop() {
+        if (selectedOpMode != null) selectedOpMode.stop();
+    }
+}

--- a/Twenty403/src/main/java/org/firstinspires/ftc/twenty403/opmodes/Tuning.java
+++ b/Twenty403/src/main/java/org/firstinspires/ftc/twenty403/opmodes/Tuning.java
@@ -1,6 +1,5 @@
 package org.firstinspires.ftc.twenty403.opmodes;
 
-
 import static org.firstinspires.ftc.twenty403.opmodes.Tuning.changes;
 import static org.firstinspires.ftc.twenty403.opmodes.Tuning.draw;
 import static org.firstinspires.ftc.twenty403.opmodes.Tuning.drawOnlyCurrent;
@@ -20,17 +19,15 @@ import com.pedropathing.follower.Follower;
 import com.pedropathing.geometry.*;
 import com.pedropathing.math.*;
 import com.pedropathing.paths.*;
-import com.pedropathing.telemetry.SelectableOpMode;
 import com.pedropathing.util.*;
 import com.qualcomm.hardware.sparkfun.SparkFunOTOS;
 import com.qualcomm.robotcore.eventloop.opmode.OpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
-
-import org.firstinspires.ftc.twenty403.AutoConstants;
-import org.firstinspires.ftc.twenty403.Setup;
-
+import com.technototes.library.structure.BetterSelectableOpMode;
 import java.util.ArrayList;
 import java.util.List;
+import org.firstinspires.ftc.twenty403.AutoConstants;
+import org.firstinspires.ftc.twenty403.Setup;
 
 /**
  * This is the Tuning class. It contains a selection menu for various tuning OpModes.
@@ -40,7 +37,8 @@ import java.util.List;
  */
 @Configurable
 @TeleOp(name = "Tuning", group = "Pedro Pathing")
-public class Tuning extends SelectableOpMode {
+public class Tuning extends BetterSelectableOpMode {
+
     public static Follower follower;
 
     @IgnoreConfigurable
@@ -63,8 +61,14 @@ public class Tuning extends SelectableOpMode {
             s.folder("Automatic", a -> {
                 a.add("Forward Velocity Tuner", ForwardVelocityTuner::new);
                 a.add("Lateral Velocity Tuner", LateralVelocityTuner::new);
-                a.add("Forward Zero Power Acceleration Tuner", ForwardZeroPowerAccelerationTuner::new);
-                a.add("Lateral Zero Power Acceleration Tuner", LateralZeroPowerAccelerationTuner::new);
+                a.add(
+                    "Forward Zero Power Acceleration Tuner",
+                    ForwardZeroPowerAccelerationTuner::new
+                );
+                a.add(
+                    "Lateral Zero Power Acceleration Tuner",
+                    LateralZeroPowerAccelerationTuner::new
+                );
             });
             s.folder("Manual", p -> {
                 p.add("Translational Tuner", TranslationalTuner::new);
@@ -115,7 +119,7 @@ public class Tuning extends SelectableOpMode {
     /** This creates a full stop of the robot by setting the drive motors to run at 0 power. */
     public static void stopRobot() {
         follower.startTeleopDrive(true);
-        follower.setTeleOpDrive(0,0,0,true);
+        follower.setTeleOpDrive(0, 0, 0, true);
     }
 }
 
@@ -129,16 +133,20 @@ public class Tuning extends SelectableOpMode {
  * @version 1.0, 5/6/2024
  */
 class LocalizationTest extends OpMode {
+
     @Override
     public void init() {
         SparkFunOTOS otos = hardwareMap.get(SparkFunOTOS.class, Setup.HardwareNames.OTOS);
-        otos.calibrateImu();}
+        otos.calibrateImu();
+    }
 
     /** This initializes the PoseUpdater, the mecanum drive motors, and the Panels telemetry. */
     @Override
     public void init_loop() {
-        telemetryM.debug("This will print your robot's position to telemetry while "
-                + "allowing robot control through a basic mecanum drive on gamepad 1.");
+        telemetryM.debug(
+            "This will print your robot's position to telemetry while " +
+                "allowing robot control through a basic mecanum drive on gamepad 1."
+        );
         telemetryM.update(telemetry);
         follower.update();
         drawOnlyCurrent();
@@ -156,7 +164,12 @@ class LocalizationTest extends OpMode {
      */
     @Override
     public void loop() {
-        follower.setTeleOpDrive(-gamepad1.left_stick_y, -gamepad1.left_stick_x, -gamepad1.right_stick_x, true);
+        follower.setTeleOpDrive(
+            -gamepad1.left_stick_y,
+            -gamepad1.left_stick_x,
+            -gamepad1.right_stick_x,
+            true
+        );
         follower.update();
 
         telemetryM.debug("x:" + follower.getPose().getX());
@@ -183,11 +196,12 @@ class LocalizationTest extends OpMode {
  * @version 1.0, 5/6/2024
  */
 class ForwardTuner extends OpMode {
+
     public static double DISTANCE = 48;
 
     @Override
     public void init() {
-        SparkFunOTOS otos = hardwareMap.get(SparkFunOTOS.class,Setup.HardwareNames.OTOS);
+        SparkFunOTOS otos = hardwareMap.get(SparkFunOTOS.class, Setup.HardwareNames.OTOS);
         otos.calibrateImu();
         follower.update();
         drawOnlyCurrent();
@@ -196,7 +210,11 @@ class ForwardTuner extends OpMode {
     /** This initializes the PoseUpdater as well as the Panels telemetry. */
     @Override
     public void init_loop() {
-        telemetryM.debug("Pull your robot forward " + DISTANCE + " inches. Your forward ticks to inches will be shown on the telemetry.");
+        telemetryM.debug(
+            "Pull your robot forward " +
+                DISTANCE +
+                " inches. Your forward ticks to inches will be shown on the telemetry."
+        );
         telemetryM.update(telemetry);
         drawOnlyCurrent();
     }
@@ -210,8 +228,17 @@ class ForwardTuner extends OpMode {
         follower.update();
 
         telemetryM.debug("Distance Moved: " + follower.getPose().getX());
-        telemetryM.debug("The multiplier will display what your forward ticks to inches should be to scale your current distance to " + DISTANCE + " inches.");
-        telemetryM.debug("Multiplier: " + (DISTANCE / (follower.getPose().getX() / follower.getPoseTracker().getLocalizer().getForwardMultiplier())));
+        telemetryM.debug(
+            "The multiplier will display what your forward ticks to inches should be to scale your current distance to " +
+                DISTANCE +
+                " inches."
+        );
+        telemetryM.debug(
+            "Multiplier: " +
+                (DISTANCE /
+                    (follower.getPose().getX() /
+                        follower.getPoseTracker().getLocalizer().getForwardMultiplier()))
+        );
         telemetryM.update(telemetry);
 
         draw();
@@ -232,11 +259,12 @@ class ForwardTuner extends OpMode {
  * @version 2.0, 6/26/2025
  */
 class LateralTuner extends OpMode {
+
     public static double DISTANCE = 48;
 
     @Override
     public void init() {
-        SparkFunOTOS otos = hardwareMap.get(SparkFunOTOS.class,Setup.HardwareNames.OTOS);
+        SparkFunOTOS otos = hardwareMap.get(SparkFunOTOS.class, Setup.HardwareNames.OTOS);
         otos.calibrateImu();
         follower.update();
         drawOnlyCurrent();
@@ -245,7 +273,11 @@ class LateralTuner extends OpMode {
     /** This initializes the PoseUpdater as well as the Panels telemetry. */
     @Override
     public void init_loop() {
-        telemetryM.debug("Pull your robot to the right " + DISTANCE + " inches. Your strafe ticks to inches will be shown on the telemetry.");
+        telemetryM.debug(
+            "Pull your robot to the right " +
+                DISTANCE +
+                " inches. Your strafe ticks to inches will be shown on the telemetry."
+        );
         telemetryM.update(telemetry);
         drawOnlyCurrent();
     }
@@ -259,8 +291,17 @@ class LateralTuner extends OpMode {
         follower.update();
 
         telemetryM.debug("Distance Moved: " + follower.getPose().getY());
-        telemetryM.debug("The multiplier will display what your strafe ticks to inches should be to scale your current distance to " + DISTANCE + " inches.");
-        telemetryM.debug("Multiplier: " + (DISTANCE / (follower.getPose().getY() / follower.getPoseTracker().getLocalizer().getLateralMultiplier())));
+        telemetryM.debug(
+            "The multiplier will display what your strafe ticks to inches should be to scale your current distance to " +
+                DISTANCE +
+                " inches."
+        );
+        telemetryM.debug(
+            "Multiplier: " +
+                (DISTANCE /
+                    (follower.getPose().getY() /
+                        follower.getPoseTracker().getLocalizer().getLateralMultiplier()))
+        );
         telemetryM.update(telemetry);
 
         draw();
@@ -281,11 +322,12 @@ class LateralTuner extends OpMode {
  * @version 1.0, 5/6/2024
  */
 class TurnTuner extends OpMode {
+
     public static double ANGLE = 2 * Math.PI;
 
     @Override
     public void init() {
-        SparkFunOTOS otos = hardwareMap.get(SparkFunOTOS.class,Setup.HardwareNames.OTOS);
+        SparkFunOTOS otos = hardwareMap.get(SparkFunOTOS.class, Setup.HardwareNames.OTOS);
         otos.calibrateImu();
         follower.update();
         drawOnlyCurrent();
@@ -294,7 +336,11 @@ class TurnTuner extends OpMode {
     /** This initializes the PoseUpdater as well as the Panels telemetry. */
     @Override
     public void init_loop() {
-        telemetryM.debug("Turn your robot " + Math.toDegrees(ANGLE) + " Degrees. Your turn ticks to inches will be shown on the telemetry.");
+        telemetryM.debug(
+            "Turn your robot " +
+                Math.toDegrees(ANGLE) +
+                " Degrees. Your turn ticks to inches will be shown on the telemetry."
+        );
         telemetryM.update(telemetry);
 
         drawOnlyCurrent();
@@ -309,8 +355,17 @@ class TurnTuner extends OpMode {
         follower.update();
 
         telemetryM.debug("Total Angle: " + follower.getTotalHeading());
-        telemetryM.debug("The multiplier will display what your turn ticks to inches should be to scale your current angle to " + ANGLE + " radians.");
-        telemetryM.debug("Multiplier: " + (ANGLE / (follower.getTotalHeading() / follower.getPoseTracker().getLocalizer().getTurningMultiplier())));
+        telemetryM.debug(
+            "The multiplier will display what your turn ticks to inches should be to scale your current angle to " +
+                ANGLE +
+                " radians."
+        );
+        telemetryM.debug(
+            "Multiplier: " +
+                (ANGLE /
+                    (follower.getTotalHeading() /
+                        follower.getPoseTracker().getLocalizer().getTurningMultiplier()))
+        );
         telemetryM.update(telemetry);
 
         draw();
@@ -333,6 +388,7 @@ class TurnTuner extends OpMode {
  * @version 1.0, 3/13/2024
  */
 class ForwardVelocityTuner extends OpMode {
+
     private final ArrayList<Double> velocities = new ArrayList<>();
     public static double DISTANCE = 48;
     public static double RECORD_NUMBER = 10;
@@ -340,15 +396,23 @@ class ForwardVelocityTuner extends OpMode {
     private boolean end;
 
     @Override
-    public void init() {SparkFunOTOS otos = hardwareMap.get(SparkFunOTOS.class,Setup.HardwareNames.OTOS);
-        otos.calibrateImu();}
+    public void init() {
+        SparkFunOTOS otos = hardwareMap.get(SparkFunOTOS.class, Setup.HardwareNames.OTOS);
+        otos.calibrateImu();
+    }
 
     /** This initializes the drive motors as well as the cache of velocities and the Panels telemetry. */
     @Override
     public void init_loop() {
-        telemetryM.debug("The robot will run at 1 power until it reaches " + DISTANCE + " inches forward.");
-        telemetryM.debug("Make sure you have enough room, since the robot has inertia after cutting power.");
-        telemetryM.debug("After running the distance, the robot will cut power from the drivetrain and display the forward velocity.");
+        telemetryM.debug(
+            "The robot will run at 1 power until it reaches " + DISTANCE + " inches forward."
+        );
+        telemetryM.debug(
+            "Make sure you have enough room, since the robot has inertia after cutting power."
+        );
+        telemetryM.debug(
+            "After running the distance, the robot will cut power from the drivetrain and display the forward velocity."
+        );
         telemetryM.debug("Press B on game pad 1 to stop.");
         telemetryM.debug("pose", follower.getPose());
         telemetryM.update(telemetry);
@@ -384,7 +448,6 @@ class ForwardVelocityTuner extends OpMode {
         follower.update();
         draw();
 
-
         if (!end) {
             Pose p = follower.getPose();
             telemetry.addData("PoseX", p.getX());
@@ -395,9 +458,11 @@ class ForwardVelocityTuner extends OpMode {
                 end = true;
                 stopRobot();
             } else {
-                follower.setTeleOpDrive(1,0,0,true);
+                follower.setTeleOpDrive(1, 0, 0, true);
                 //double currentVelocity = Math.abs(follower.getVelocity().getXComponent());
-                double currentVelocity = Math.abs(follower.poseTracker.getLocalizer().getVelocity().getY());
+                double currentVelocity = Math.abs(
+                    follower.poseTracker.getLocalizer().getVelocity().getY()
+                );
                 velocities.add(currentVelocity);
                 velocities.remove(0);
             }
@@ -410,7 +475,9 @@ class ForwardVelocityTuner extends OpMode {
             average /= velocities.size();
             telemetryM.debug("Forward Velocity: " + average);
             telemetryM.debug("\n");
-            telemetryM.debug("Press A to set the Forward Velocity temporarily (while robot remains on).");
+            telemetryM.debug(
+                "Press A to set the Forward Velocity temporarily (while robot remains on)."
+            );
 
             for (int i = 0; i < velocities.size(); i++) {
                 telemetry.addData(String.valueOf(i), velocities.get(i));
@@ -444,6 +511,7 @@ class ForwardVelocityTuner extends OpMode {
  * @version 1.0, 3/13/2024
  */
 class LateralVelocityTuner extends OpMode {
+
     private final ArrayList<Double> velocities = new ArrayList<>();
 
     public static double DISTANCE = 48;
@@ -452,8 +520,10 @@ class LateralVelocityTuner extends OpMode {
     private boolean end;
 
     @Override
-    public void init() {SparkFunOTOS otos = hardwareMap.get(SparkFunOTOS.class,Setup.HardwareNames.OTOS);
-        otos.calibrateImu();}
+    public void init() {
+        SparkFunOTOS otos = hardwareMap.get(SparkFunOTOS.class, Setup.HardwareNames.OTOS);
+        otos.calibrateImu();
+    }
 
     /**
      * This initializes the drive motors as well as the cache of velocities and the Panels
@@ -461,9 +531,15 @@ class LateralVelocityTuner extends OpMode {
      */
     @Override
     public void init_loop() {
-        telemetryM.debug("The robot will run at 1 power until it reaches " + DISTANCE + " inches to the right.");
-        telemetryM.debug("Make sure you have enough room, since the robot has inertia after cutting power.");
-        telemetryM.debug("After running the distance, the robot will cut power from the drivetrain and display the strafe velocity.");
+        telemetryM.debug(
+            "The robot will run at 1 power until it reaches " + DISTANCE + " inches to the right."
+        );
+        telemetryM.debug(
+            "Make sure you have enough room, since the robot has inertia after cutting power."
+        );
+        telemetryM.debug(
+            "After running the distance, the robot will cut power from the drivetrain and display the strafe velocity."
+        );
         telemetryM.debug("Press B on Gamepad 1 to stop.");
         telemetryM.update(telemetry);
 
@@ -502,8 +578,10 @@ class LateralVelocityTuner extends OpMode {
                 end = true;
                 stopRobot();
             } else {
-                follower.setTeleOpDrive(0,1,0,true);
-                double currentVelocity = Math.abs(follower.poseTracker.getLocalizer().getVelocity().getX());
+                follower.setTeleOpDrive(0, 1, 0, true);
+                double currentVelocity = Math.abs(
+                    follower.poseTracker.getLocalizer().getVelocity().getX()
+                );
                 velocities.add(currentVelocity);
                 velocities.remove(0);
             }
@@ -517,7 +595,9 @@ class LateralVelocityTuner extends OpMode {
 
             telemetryM.debug("Strafe Velocity: " + average);
             telemetryM.debug("\n");
-            telemetryM.debug("Press A to set the Lateral Velocity temporarily (while robot remains on).");
+            telemetryM.debug(
+                "Press A to set the Lateral Velocity temporarily (while robot remains on)."
+            );
             telemetryM.update(telemetry);
 
             if (gamepad1.aWasPressed()) {
@@ -545,6 +625,7 @@ class LateralVelocityTuner extends OpMode {
  * @version 1.0, 3/13/2024
  */
 class ForwardZeroPowerAccelerationTuner extends OpMode {
+
     private final ArrayList<Double> accelerations = new ArrayList<>();
     public static double VELOCITY = 30;
 
@@ -555,16 +636,22 @@ class ForwardZeroPowerAccelerationTuner extends OpMode {
     private boolean end;
 
     @Override
-    public void init() {SparkFunOTOS otos = hardwareMap.get(SparkFunOTOS.class,Setup.HardwareNames.OTOS);
-        otos.calibrateImu();}
+    public void init() {
+        SparkFunOTOS otos = hardwareMap.get(SparkFunOTOS.class, Setup.HardwareNames.OTOS);
+        otos.calibrateImu();
+    }
 
     /** This initializes the drive motors as well as the Panels telemetryM. */
     @Override
     public void init_loop() {
-        telemetryM.debug("The robot will run forward until it reaches " + VELOCITY + " inches per second.");
+        telemetryM.debug(
+            "The robot will run forward until it reaches " + VELOCITY + " inches per second."
+        );
         telemetryM.debug("Then, it will cut power from the drivetrain and roll to a stop.");
         telemetryM.debug("Make sure you have enough room.");
-        telemetryM.debug("After stopping, the forward zero power acceleration (natural deceleration) will be displayed.");
+        telemetryM.debug(
+            "After stopping, the forward zero power acceleration (natural deceleration) will be displayed."
+        );
         telemetryM.debug("Press B on Gamepad 1 to stop.");
         telemetryM.update(telemetry);
         follower.update();
@@ -576,7 +663,7 @@ class ForwardZeroPowerAccelerationTuner extends OpMode {
     public void start() {
         follower.startTeleopDrive(false);
         follower.update();
-        follower.setTeleOpDrive(1,0,0,true);
+        follower.setTeleOpDrive(1, 0, 0, true);
     }
 
     /**
@@ -602,11 +689,14 @@ class ForwardZeroPowerAccelerationTuner extends OpMode {
                     previousVelocity = follower.getVelocity().dot(heading);
                     previousTimeNano = System.nanoTime();
                     stopping = true;
-                    follower.setTeleOpDrive(0,0,0,true);
+                    follower.setTeleOpDrive(0, 0, 0, true);
                 }
             } else {
                 double currentVelocity = follower.getVelocity().dot(heading);
-                accelerations.add((currentVelocity - previousVelocity) / ((System.nanoTime() - previousTimeNano) / Math.pow(10.0, 9)));
+                accelerations.add(
+                    (currentVelocity - previousVelocity) /
+                        ((System.nanoTime() - previousTimeNano) / Math.pow(10.0, 9))
+                );
                 previousVelocity = currentVelocity;
                 previousTimeNano = System.nanoTime();
                 if (currentVelocity < follower.getConstraints().getVelocityConstraint()) {
@@ -622,7 +712,9 @@ class ForwardZeroPowerAccelerationTuner extends OpMode {
 
             telemetryM.debug("Forward Zero Power Acceleration (Deceleration): " + average);
             telemetryM.debug("\n");
-            telemetryM.debug("Press A to set the Forward Zero Power Acceleration temporarily (while robot remains on).");
+            telemetryM.debug(
+                "Press A to set the Forward Zero Power Acceleration temporarily (while robot remains on)."
+            );
             telemetryM.update(telemetry);
 
             if (gamepad1.aWasPressed()) {
@@ -650,6 +742,7 @@ class ForwardZeroPowerAccelerationTuner extends OpMode {
  * @version 1.0, 3/13/2024
  */
 class LateralZeroPowerAccelerationTuner extends OpMode {
+
     private final ArrayList<Double> accelerations = new ArrayList<>();
     public static double VELOCITY = 30;
     private double previousVelocity;
@@ -658,16 +751,22 @@ class LateralZeroPowerAccelerationTuner extends OpMode {
     private boolean end;
 
     @Override
-    public void init() {SparkFunOTOS otos = hardwareMap.get(SparkFunOTOS.class,Setup.HardwareNames.OTOS);
-        otos.calibrateImu();}
+    public void init() {
+        SparkFunOTOS otos = hardwareMap.get(SparkFunOTOS.class, Setup.HardwareNames.OTOS);
+        otos.calibrateImu();
+    }
 
     /** This initializes the drive motors as well as the Panels telemetry. */
     @Override
     public void init_loop() {
-        telemetryM.debug("The robot will run to the right until it reaches " + VELOCITY + " inches per second.");
+        telemetryM.debug(
+            "The robot will run to the right until it reaches " + VELOCITY + " inches per second."
+        );
         telemetryM.debug("Then, it will cut power from the drivetrain and roll to a stop.");
         telemetryM.debug("Make sure you have enough room.");
-        telemetryM.debug("After stopping, the lateral zero power acceleration (natural deceleration) will be displayed.");
+        telemetryM.debug(
+            "After stopping, the lateral zero power acceleration (natural deceleration) will be displayed."
+        );
         telemetryM.debug("Press B on game pad 1 to stop.");
         telemetryM.update(telemetry);
         follower.update();
@@ -679,7 +778,7 @@ class LateralZeroPowerAccelerationTuner extends OpMode {
     public void start() {
         follower.startTeleopDrive(false);
         follower.update();
-        follower.setTeleOpDrive(0,1,0,true);
+        follower.setTeleOpDrive(0, 1, 0, true);
     }
 
     /**
@@ -705,11 +804,14 @@ class LateralZeroPowerAccelerationTuner extends OpMode {
                     previousVelocity = Math.abs(follower.getVelocity().dot(heading));
                     previousTimeNano = System.nanoTime();
                     stopping = true;
-                    follower.setTeleOpDrive(0,0,0,true);
+                    follower.setTeleOpDrive(0, 0, 0, true);
                 }
             } else {
                 double currentVelocity = Math.abs(follower.getVelocity().dot(heading));
-                accelerations.add((currentVelocity - previousVelocity) / ((System.nanoTime() - previousTimeNano) / Math.pow(10.0, 9)));
+                accelerations.add(
+                    (currentVelocity - previousVelocity) /
+                        ((System.nanoTime() - previousTimeNano) / Math.pow(10.0, 9))
+                );
                 previousVelocity = currentVelocity;
                 previousTimeNano = System.nanoTime();
                 if (currentVelocity < follower.getConstraints().getVelocityConstraint()) {
@@ -725,7 +827,9 @@ class LateralZeroPowerAccelerationTuner extends OpMode {
 
             telemetryM.debug("Lateral Zero Power Acceleration (Deceleration): " + average);
             telemetryM.debug("\n");
-            telemetryM.debug("Press A to set the Lateral Zero Power Acceleration temporarily (while robot remains on).");
+            telemetryM.debug(
+                "Press A to set the Lateral Zero Power Acceleration temporarily (while robot remains on)."
+            );
             telemetryM.update(telemetry);
 
             if (gamepad1.aWasPressed()) {
@@ -748,6 +852,7 @@ class LateralZeroPowerAccelerationTuner extends OpMode {
  * @version 1.0, 3/12/2024
  */
 class TranslationalTuner extends OpMode {
+
     public static double DISTANCE = 40;
     private boolean forward = true;
 
@@ -755,15 +860,19 @@ class TranslationalTuner extends OpMode {
     private Path backwards;
 
     @Override
-    public void init() {SparkFunOTOS otos = hardwareMap.get(SparkFunOTOS.class,Setup.HardwareNames.OTOS);
-        otos.calibrateImu();}
+    public void init() {
+        SparkFunOTOS otos = hardwareMap.get(SparkFunOTOS.class, Setup.HardwareNames.OTOS);
+        otos.calibrateImu();
+    }
 
     /** This initializes the Follower and creates the forward and backward Paths. */
     @Override
     public void init_loop() {
         telemetryM.debug("This will activate the translational PIDF(s)");
         telemetryM.debug("The robot will try to stay in place while you push it laterally.");
-        telemetryM.debug("You can adjust the PIDF values to tune the robot's translational PIDF(s).");
+        telemetryM.debug(
+            "You can adjust the PIDF values to tune the robot's translational PIDF(s)."
+        );
         telemetryM.update(telemetry);
         follower.update();
         drawOnlyCurrent();
@@ -773,9 +882,9 @@ class TranslationalTuner extends OpMode {
     public void start() {
         follower.deactivateAllPIDFs();
         follower.activateTranslational();
-        forwards = new Path(new BezierLine(new Pose(0,0), new Pose(DISTANCE,0)));
+        forwards = new Path(new BezierLine(new Pose(0, 0), new Pose(DISTANCE, 0)));
         forwards.setConstantHeadingInterpolation(0);
-        backwards = new Path(new BezierLine(new Pose(DISTANCE,0), new Pose(0,0)));
+        backwards = new Path(new BezierLine(new Pose(DISTANCE, 0), new Pose(0, 0)));
         backwards.setConstantHeadingInterpolation(0);
         follower.followPath(forwards);
     }
@@ -813,6 +922,7 @@ class TranslationalTuner extends OpMode {
  * @version 1.0, 3/12/2024
  */
 class HeadingTuner extends OpMode {
+
     public static double DISTANCE = 40;
     private boolean forward = true;
 
@@ -820,8 +930,10 @@ class HeadingTuner extends OpMode {
     private Path backwards;
 
     @Override
-    public void init() {SparkFunOTOS otos = hardwareMap.get(SparkFunOTOS.class,Setup.HardwareNames.OTOS);
-        otos.calibrateImu();}
+    public void init() {
+        SparkFunOTOS otos = hardwareMap.get(SparkFunOTOS.class, Setup.HardwareNames.OTOS);
+        otos.calibrateImu();
+    }
 
     /**
      * This initializes the Follower and creates the forward and backward Paths. Additionally, this
@@ -830,7 +942,9 @@ class HeadingTuner extends OpMode {
     @Override
     public void init_loop() {
         telemetryM.debug("This will activate the heading PIDF(s).");
-        telemetryM.debug("The robot will try to stay at a constant heading while you try to turn it.");
+        telemetryM.debug(
+            "The robot will try to stay at a constant heading while you try to turn it."
+        );
         telemetryM.debug("You can adjust the PIDF values to tune the robot's heading PIDF(s).");
         telemetryM.update(telemetry);
         follower.update();
@@ -841,9 +955,9 @@ class HeadingTuner extends OpMode {
     public void start() {
         follower.deactivateAllPIDFs();
         follower.activateHeading();
-        forwards = new Path(new BezierLine(new Pose(0,0), new Pose(DISTANCE,0)));
+        forwards = new Path(new BezierLine(new Pose(0, 0), new Pose(DISTANCE, 0)));
         forwards.setConstantHeadingInterpolation(0);
-        backwards = new Path(new BezierLine(new Pose(DISTANCE,0), new Pose(0,0)));
+        backwards = new Path(new BezierLine(new Pose(DISTANCE, 0), new Pose(0, 0)));
         backwards.setConstantHeadingInterpolation(0);
         follower.followPath(forwards);
     }
@@ -882,6 +996,7 @@ class HeadingTuner extends OpMode {
  * @version 1.0, 3/12/2024
  */
 class DriveTuner extends OpMode {
+
     public static double DISTANCE = 40;
     private boolean forward = true;
 
@@ -889,8 +1004,10 @@ class DriveTuner extends OpMode {
     private PathChain backwards;
 
     @Override
-    public void init() {SparkFunOTOS otos = hardwareMap.get(SparkFunOTOS.class,Setup.HardwareNames.OTOS);
-        otos.calibrateImu();}
+    public void init() {
+        SparkFunOTOS otos = hardwareMap.get(SparkFunOTOS.class, Setup.HardwareNames.OTOS);
+        otos.calibrateImu();
+    }
 
     /**
      * This initializes the Follower and creates the forward and backward Paths. Additionally, this
@@ -898,7 +1015,9 @@ class DriveTuner extends OpMode {
      */
     @Override
     public void init_loop() {
-        telemetryM.debug("This will run the robot in a straight line going " + DISTANCE + "inches forward.");
+        telemetryM.debug(
+            "This will run the robot in a straight line going " + DISTANCE + "inches forward."
+        );
         telemetryM.debug("The robot will go forward and backward continuously along the path.");
         telemetryM.debug("Make sure you have enough room.");
         telemetryM.update(telemetry);
@@ -911,17 +1030,19 @@ class DriveTuner extends OpMode {
         follower.deactivateAllPIDFs();
         follower.activateDrive();
 
-        forwards = follower.pathBuilder()
-                .setGlobalDeceleration()
-                .addPath(new BezierLine(new Pose(0,0), new Pose(DISTANCE,0)))
-                .setConstantHeadingInterpolation(0)
-                .build();
+        forwards = follower
+            .pathBuilder()
+            .setGlobalDeceleration()
+            .addPath(new BezierLine(new Pose(0, 0), new Pose(DISTANCE, 0)))
+            .setConstantHeadingInterpolation(0)
+            .build();
 
-        backwards = follower.pathBuilder()
-                .setGlobalDeceleration()
-                .addPath(new BezierLine(new Pose(DISTANCE,0), new Pose(0,0)))
-                .setConstantHeadingInterpolation(0)
-                .build();
+        backwards = follower
+            .pathBuilder()
+            .setGlobalDeceleration()
+            .addPath(new BezierLine(new Pose(DISTANCE, 0), new Pose(0, 0)))
+            .setConstantHeadingInterpolation(0)
+            .build();
 
         follower.followPath(forwards);
     }
@@ -961,6 +1082,7 @@ class DriveTuner extends OpMode {
  * @version 1.0, 3/12/2024
  */
 class Line extends OpMode {
+
     public static double DISTANCE = 40;
     private boolean forward = true;
 
@@ -968,14 +1090,18 @@ class Line extends OpMode {
     private Path backwards;
 
     @Override
-    public void init() {SparkFunOTOS otos = hardwareMap.get(SparkFunOTOS.class,Setup.HardwareNames.OTOS);
-        otos.calibrateImu();}
+    public void init() {
+        SparkFunOTOS otos = hardwareMap.get(SparkFunOTOS.class, Setup.HardwareNames.OTOS);
+        otos.calibrateImu();
+    }
 
     /** This initializes the Follower and creates the forward and backward Paths. */
     @Override
     public void init_loop() {
         telemetryM.debug("This will activate all the PIDF(s)");
-        telemetryM.debug("The robot will go forward and backward continuously along the path while correcting.");
+        telemetryM.debug(
+            "The robot will go forward and backward continuously along the path while correcting."
+        );
         telemetryM.debug("You can adjust the PIDF values to tune the robot's drive PIDF(s).");
         telemetryM.update(telemetry);
         follower.update();
@@ -985,9 +1111,9 @@ class Line extends OpMode {
     @Override
     public void start() {
         follower.activateAllPIDFs();
-        forwards = new Path(new BezierLine(new Pose(0,0), new Pose(DISTANCE,0)));
+        forwards = new Path(new BezierLine(new Pose(0, 0), new Pose(DISTANCE, 0)));
         forwards.setConstantHeadingInterpolation(0);
-        backwards = new Path(new BezierLine(new Pose(DISTANCE,0), new Pose(0,0)));
+        backwards = new Path(new BezierLine(new Pose(DISTANCE, 0), new Pose(0, 0)));
         backwards.setConstantHeadingInterpolation(0);
         follower.followPath(forwards);
     }
@@ -1027,6 +1153,7 @@ class Line extends OpMode {
  * @version 1.0, 3/13/2024
  */
 class CentripetalTuner extends OpMode {
+
     public static double DISTANCE = 20;
     private boolean forward = true;
 
@@ -1034,8 +1161,10 @@ class CentripetalTuner extends OpMode {
     private Path backwards;
 
     @Override
-    public void init() {SparkFunOTOS otos = hardwareMap.get(SparkFunOTOS.class,Setup.HardwareNames.OTOS);
-        otos.calibrateImu();}
+    public void init() {
+        SparkFunOTOS otos = hardwareMap.get(SparkFunOTOS.class, Setup.HardwareNames.OTOS);
+        otos.calibrateImu();
+    }
 
     /**
      * This initializes the Follower and creates the forward and backward Paths.
@@ -1043,7 +1172,11 @@ class CentripetalTuner extends OpMode {
      */
     @Override
     public void init_loop() {
-        telemetryM.debug("This will run the robot in a curve going " + DISTANCE + " inches to the left and the same number of inches forward.");
+        telemetryM.debug(
+            "This will run the robot in a curve going " +
+                DISTANCE +
+                " inches to the left and the same number of inches forward."
+        );
         telemetryM.debug("The robot will go continuously along the path.");
         telemetryM.debug("Make sure you have enough room.");
         telemetryM.update(telemetry);
@@ -1054,8 +1187,20 @@ class CentripetalTuner extends OpMode {
     @Override
     public void start() {
         follower.activateAllPIDFs();
-        forwards = new Path(new BezierCurve(new Pose(), new Pose(Math.abs(DISTANCE),0), new Pose(Math.abs(DISTANCE),DISTANCE)));
-        backwards = new Path(new BezierCurve(new Pose(Math.abs(DISTANCE),DISTANCE), new Pose(Math.abs(DISTANCE),0), new Pose(0,0)));
+        forwards = new Path(
+            new BezierCurve(
+                new Pose(),
+                new Pose(Math.abs(DISTANCE), 0),
+                new Pose(Math.abs(DISTANCE), DISTANCE)
+            )
+        );
+        backwards = new Path(
+            new BezierCurve(
+                new Pose(Math.abs(DISTANCE), DISTANCE),
+                new Pose(Math.abs(DISTANCE), 0),
+                new Pose(0, 0)
+            )
+        );
 
         backwards.setTangentHeadingInterpolation();
         backwards.reverseHeadingInterpolation();
@@ -1117,13 +1262,19 @@ class Triangle extends OpMode {
     }
 
     @Override
-    public void init() {SparkFunOTOS otos = hardwareMap.get(SparkFunOTOS.class,Setup.HardwareNames.OTOS);
-        otos.calibrateImu();}
+    public void init() {
+        SparkFunOTOS otos = hardwareMap.get(SparkFunOTOS.class, Setup.HardwareNames.OTOS);
+        otos.calibrateImu();
+    }
 
     @Override
     public void init_loop() {
-        telemetryM.debug("This will run in a roughly triangular shape, starting on the bottom-middle point.");
-        telemetryM.debug("So, make sure you have enough space to the left, front, and right to run the OpMode.");
+        telemetryM.debug(
+            "This will run in a roughly triangular shape, starting on the bottom-middle point."
+        );
+        telemetryM.debug(
+            "So, make sure you have enough space to the left, front, and right to run the OpMode."
+        );
         telemetryM.update(telemetry);
         follower.update();
         drawOnlyCurrent();
@@ -1134,14 +1285,15 @@ class Triangle extends OpMode {
     public void start() {
         follower.setStartingPose(startPose);
 
-        triangle = follower.pathBuilder()
-                .addPath(new BezierLine(startPose, interPose))
-                .setLinearHeadingInterpolation(startPose.getHeading(), interPose.getHeading())
-                .addPath(new BezierLine(interPose, endPose))
-                .setLinearHeadingInterpolation(interPose.getHeading(), endPose.getHeading())
-                .addPath(new BezierLine(endPose, startPose))
-                .setLinearHeadingInterpolation(endPose.getHeading(), startPose.getHeading())
-                .build();
+        triangle = follower
+            .pathBuilder()
+            .addPath(new BezierLine(startPose, interPose))
+            .setLinearHeadingInterpolation(startPose.getHeading(), interPose.getHeading())
+            .addPath(new BezierLine(interPose, endPose))
+            .setLinearHeadingInterpolation(interPose.getHeading(), endPose.getHeading())
+            .addPath(new BezierLine(endPose, startPose))
+            .setLinearHeadingInterpolation(endPose.getHeading(), startPose.getHeading())
+            .build();
 
         follower.followPath(triangle);
     }
@@ -1159,36 +1311,62 @@ class Triangle extends OpMode {
  * @version 1.0, 3/12/2024
  */
 class Circle extends OpMode {
+
     public static double RADIUS = 10;
     private PathChain circle;
 
     public void start() {
-        circle = follower.pathBuilder()
-                .addPath(new BezierCurve(new Pose(0, 0), new Pose(RADIUS, 0), new Pose(RADIUS, RADIUS)))
-                .setHeadingInterpolation(HeadingInterpolator.facingPoint(0, RADIUS))
-                .addPath(new BezierCurve(new Pose(RADIUS, RADIUS), new Pose(RADIUS, 2 * RADIUS), new Pose(0, 2 * RADIUS)))
-                .setHeadingInterpolation(HeadingInterpolator.facingPoint(0, RADIUS))
-                .addPath(new BezierCurve(new Pose(0, 2 * RADIUS), new Pose(-RADIUS, 2 * RADIUS), new Pose(-RADIUS, RADIUS)))
-                .setHeadingInterpolation(HeadingInterpolator.facingPoint(0, RADIUS))
-                .addPath(new BezierCurve(new Pose(-RADIUS, RADIUS), new Pose(-RADIUS, 0), new Pose(0, 0)))
-                .setHeadingInterpolation(HeadingInterpolator.facingPoint(0, RADIUS))
-                .build();
+        circle = follower
+            .pathBuilder()
+            .addPath(new BezierCurve(new Pose(0, 0), new Pose(RADIUS, 0), new Pose(RADIUS, RADIUS)))
+            .setHeadingInterpolation(HeadingInterpolator.facingPoint(0, RADIUS))
+            .addPath(
+                new BezierCurve(
+                    new Pose(RADIUS, RADIUS),
+                    new Pose(RADIUS, 2 * RADIUS),
+                    new Pose(0, 2 * RADIUS)
+                )
+            )
+            .setHeadingInterpolation(HeadingInterpolator.facingPoint(0, RADIUS))
+            .addPath(
+                new BezierCurve(
+                    new Pose(0, 2 * RADIUS),
+                    new Pose(-RADIUS, 2 * RADIUS),
+                    new Pose(-RADIUS, RADIUS)
+                )
+            )
+            .setHeadingInterpolation(HeadingInterpolator.facingPoint(0, RADIUS))
+            .addPath(
+                new BezierCurve(new Pose(-RADIUS, RADIUS), new Pose(-RADIUS, 0), new Pose(0, 0))
+            )
+            .setHeadingInterpolation(HeadingInterpolator.facingPoint(0, RADIUS))
+            .build();
         follower.followPath(circle);
     }
 
     @Override
     public void init_loop() {
-        telemetryM.debug("This will run in a roughly circular shape of radius " + RADIUS + ", starting on the right-most edge. ");
-        telemetryM.debug("So, make sure you have enough space to the left, front, and back to run the OpMode.");
-        telemetryM.debug("It will also continuously face the center of the circle to test your heading and centripetal correction.");
+        telemetryM.debug(
+            "This will run in a roughly circular shape of radius " +
+                RADIUS +
+                ", starting on the right-most edge. "
+        );
+        telemetryM.debug(
+            "So, make sure you have enough space to the left, front, and back to run the OpMode."
+        );
+        telemetryM.debug(
+            "It will also continuously face the center of the circle to test your heading and centripetal correction."
+        );
         telemetryM.update(telemetry);
         follower.update();
         drawOnlyCurrent();
     }
 
     @Override
-    public void init() {SparkFunOTOS otos = hardwareMap.get(SparkFunOTOS.class,Setup.HardwareNames.OTOS);
-        otos.calibrateImu();}
+    public void init() {
+        SparkFunOTOS otos = hardwareMap.get(SparkFunOTOS.class, Setup.HardwareNames.OTOS);
+        otos.calibrateImu();
+    }
 
     /**
      * This runs the OpMode, updating the Follower as well as printing out the debug statements to
@@ -1212,15 +1390,12 @@ class Circle extends OpMode {
  * @version 1.1, 5/19/2025
  */
 class Drawing {
+
     public static final double ROBOT_RADIUS = 9; // woah
     private static final FieldManager panelsField = PanelsField.INSTANCE.getField();
 
-    private static final Style robotLook = new Style(
-            "", "#3F51B5", 0.75
-    );
-    private static final Style historyLook = new Style(
-            "", "#4CAF50", 0.75
-    );
+    private static final Style robotLook = new Style("", "#3F51B5", 0.75);
+    private static final Style historyLook = new Style("", "#4CAF50", 0.75);
 
     /**
      * This prepares Panels Field for using Pedro Offsets
@@ -1238,8 +1413,19 @@ class Drawing {
     public static void drawDebug(Follower follower) {
         if (follower.getCurrentPath() != null) {
             drawPath(follower.getCurrentPath(), robotLook);
-            Pose closestPoint = follower.getPointFromPath(follower.getCurrentPath().getClosestPointTValue());
-            drawRobot(new Pose(closestPoint.getX(), closestPoint.getY(), follower.getCurrentPath().getHeadingGoal(follower.getCurrentPath().getClosestPointTValue())), robotLook);
+            Pose closestPoint = follower.getPointFromPath(
+                follower.getCurrentPath().getClosestPointTValue()
+            );
+            drawRobot(
+                new Pose(
+                    closestPoint.getX(),
+                    closestPoint.getY(),
+                    follower
+                        .getCurrentPath()
+                        .getHeadingGoal(follower.getCurrentPath().getClosestPointTValue())
+                ),
+                robotLook
+            );
         }
         drawPoseHistory(follower.getPoseHistory(), historyLook);
         drawRobot(follower.getPose(), historyLook);
@@ -1255,7 +1441,12 @@ class Drawing {
      * @param style the parameters used to draw the robot with
      */
     public static void drawRobot(Pose pose, Style style) {
-        if (pose == null || Double.isNaN(pose.getX()) || Double.isNaN(pose.getY()) || Double.isNaN(pose.getHeading())) {
+        if (
+            pose == null ||
+            Double.isNaN(pose.getX()) ||
+            Double.isNaN(pose.getY()) ||
+            Double.isNaN(pose.getHeading())
+        ) {
             return;
         }
 
@@ -1265,8 +1456,10 @@ class Drawing {
 
         Vector v = pose.getHeadingAsUnitVector();
         v.setMagnitude(v.getMagnitude() * ROBOT_RADIUS);
-        double x1 = pose.getX() + v.getXComponent() / 2, y1 = pose.getY() + v.getYComponent() / 2;
-        double x2 = pose.getX() + v.getXComponent(), y2 = pose.getY() + v.getYComponent();
+        double x1 = pose.getX() + v.getXComponent() / 2,
+            y1 = pose.getY() + v.getYComponent() / 2;
+        double x2 = pose.getX() + v.getXComponent(),
+            y2 = pose.getY() + v.getYComponent();
 
         panelsField.setStyle(style);
         panelsField.moveCursor(x1, y1);
@@ -1328,9 +1521,14 @@ class Drawing {
 
         int size = poseTracker.getXPositionsArray().length;
         for (int i = 0; i < size - 1; i++) {
-
-            panelsField.moveCursor(poseTracker.getXPositionsArray()[i], poseTracker.getYPositionsArray()[i]);
-            panelsField.line(poseTracker.getXPositionsArray()[i + 1], poseTracker.getYPositionsArray()[i + 1]);
+            panelsField.moveCursor(
+                poseTracker.getXPositionsArray()[i],
+                poseTracker.getYPositionsArray()[i]
+            );
+            panelsField.line(
+                poseTracker.getXPositionsArray()[i + 1],
+                poseTracker.getYPositionsArray()[i + 1]
+            );
         }
     }
 


### PR DESCRIPTION
I had to re-implement the base class (SelectableOpMode) in TechnoLib, because the init_loop function (along with most of the rest of the functions in that opmode) are final, so you can't override them.

I should maybe make this change and put up a PR into PedroPathing, because it's just so much better to be able to use one hand to navigate...